### PR TITLE
Feat: Enable DMR and YSF modes in Config.h

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -116,4 +116,22 @@
 // Enable UDID feature
 #define ENABLE_UDID
 
+//
+// Digital Modes (You MUST enable at least one)
+//
+// Enable D-Star support.
+// #define MODE_DSTAR
+// Enable DMR support.
+#define MODE_DMR
+// Enable System Fusion support.
+#define MODE_YSF
+// Enable P25 support.
+// #define MODE_P25
+// Enable NXDN support.
+// #define MODE_NXDN
+// Enable M17 support.
+// #define MODE_M17
+// Enable POCSAG support.
+// #define MODE_POCSAG
+
 #endif


### PR DESCRIPTION
This change enables DMR and YSF modes in the `Config.h` file as per the user's request. This resolves the issue where the board was stuck with a blinking YSF LED, which indicated it was in scan mode without any specific modes enabled.

- Uncommented `#define MODE_DMR`
- Uncommented `#define MODE_YSF`
- Kept `ENABLE_SCAN_MODE` active to allow switching between the two configured modes.