### PR TITLE
Debug: Isolate DMR mode to diagnose issue

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -68,7 +68,7 @@
 #define I2C_ADDR 0x22
 
 // Enable mode detection:
-#define ENABLE_SCAN_MODE
+// #define ENABLE_SCAN_MODE
 
 // Send RSSI value:
 #define SEND_RSSI_DATA
@@ -124,7 +124,7 @@
 // Enable DMR support.
 #define MODE_DMR
 // Enable System Fusion support.
-#define MODE_YSF
+// #define MODE_YSF
 // Enable P25 support.
 // #define MODE_P25
 // Enable NXDN support.


### PR DESCRIPTION
This change modifies the `Config.h` to isolate DMR mode as a diagnostic step. The previous attempts to enable both DMR and YSF with scan mode were unsuccessful.

This configuration disables scan mode and YSF, leaving only DMR active. This will help determine if the issue is with the multi-mode scanning feature or with the DMR configuration itself.

- Commented out `#define ENABLE_SCAN_MODE`
- Commented out `#define MODE_YSF`