### PR TITLE
Fix: Set TCXO to 12.288MHz and re-enable YSF/Scan

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -45,9 +45,9 @@
 
 // TCXO of the ADF7021
 // For 14.7456 MHz:
-#define ADF7021_14_7456
+// #define ADF7021_14_7456
 // For 12.2880 MHz:
-// #define ADF7021_12_2880
+#define ADF7021_12_2880
 
 // Configure receiver gain for ADF7021
 // AGC automatic, default settings:
@@ -68,7 +68,7 @@
 #define I2C_ADDR 0x22
 
 // Enable mode detection:
-// #define ENABLE_SCAN_MODE
+#define ENABLE_SCAN_MODE
 
 // Send RSSI value:
 #define SEND_RSSI_DATA
@@ -124,7 +124,7 @@
 // Enable DMR support.
 #define MODE_DMR
 // Enable System Fusion support.
-// #define MODE_YSF
+#define MODE_YSF
 // Enable P25 support.
 // #define MODE_P25
 // Enable NXDN support.


### PR DESCRIPTION
This change modifies the `Config.h` to test the 12.288 MHz TCXO frequency setting. All previous attempts using the user-reported 14.7456 MHz frequency have failed to establish communication with Pi-Star.

This commit also re-enables YSF and Scan Mode to provide the user with their desired configuration if the TCXO change is successful.

- Set TCXO to 12.288 MHz
- Re-enabled MODE_YSF
- Re-enabled ENABLE_SCAN_MODE