### PR TITLE
This commit completes the implementation of DMR Mobile Station (handh…

### DIFF
--- a/DMRSlotRX.cpp
+++ b/DMRSlotRX.cpp
@@ -419,6 +419,54 @@ void CDMRSlotRX::correlateSync()
       m_control1 = control;
     }
     DEBUG5("SYNC corr MS Voice found slot/pos/start/end: ", m_slot ? 2U : 1U, m_dataPtr, startPtr, endPtr);
+  } else if (countBits64((m_patternBuffer & DMR_SYNC_BITS_MASK) ^ DMR_BS_DATA_SYNC_BITS) <= MAX_SYNC_BYTES_ERRS) {
+    control = CONTROL_DATA;
+    syncPtr = m_dataPtr;
+
+    startPtr = m_dataPtr + DMR_BUFFER_LENGTH_BITS - DMR_SLOT_TYPE_LENGTH_BITS / 2U - DMR_INFO_LENGTH_BITS / 2U - DMR_SYNC_LENGTH_BITS + 1;
+    if (startPtr >= DMR_BUFFER_LENGTH_BITS)
+      startPtr -= DMR_BUFFER_LENGTH_BITS;
+
+    endPtr = m_dataPtr + DMR_SLOT_TYPE_LENGTH_BITS / 2U + DMR_INFO_LENGTH_BITS / 2U;
+    if (endPtr >= DMR_BUFFER_LENGTH_BITS)
+      endPtr -= DMR_BUFFER_LENGTH_BITS;
+
+    if(m_slot) {
+      m_syncPtr2 = syncPtr;
+      m_startPtr2 = startPtr;
+      m_endPtr2 = endPtr;
+      m_control2 = control;
+    } else {
+      m_syncPtr1 = syncPtr;
+      m_startPtr1 = startPtr;
+      m_endPtr1 = endPtr;
+      m_control1 = control;
+    }
+    DEBUG5("SYNC corr BS Data found slot/pos/start/end:", m_slot ? 2U : 1U, m_dataPtr, startPtr, endPtr);
+  } else if (countBits64((m_patternBuffer & DMR_SYNC_BITS_MASK) ^ DMR_BS_VOICE_SYNC_BITS) <= MAX_SYNC_BYTES_ERRS) {
+    control  = CONTROL_VOICE;
+    syncPtr  = m_dataPtr;
+
+    startPtr = m_dataPtr + DMR_BUFFER_LENGTH_BITS - DMR_SLOT_TYPE_LENGTH_BITS / 2U - DMR_INFO_LENGTH_BITS / 2U - DMR_SYNC_LENGTH_BITS + 1;
+    if (startPtr >= DMR_BUFFER_LENGTH_BITS)
+      startPtr -= DMR_BUFFER_LENGTH_BITS;
+
+    endPtr   = m_dataPtr + DMR_SLOT_TYPE_LENGTH_BITS / 2U + DMR_INFO_LENGTH_BITS / 2U;
+    if (endPtr >= DMR_BUFFER_LENGTH_BITS)
+      endPtr -= DMR_BUFFER_LENGTH_BITS;
+
+    if(m_slot) {
+      m_syncPtr2 = syncPtr;
+      m_startPtr2 = startPtr;
+      m_endPtr2 = endPtr;
+      m_control2 = control;
+    } else {
+      m_syncPtr1 = syncPtr;
+      m_startPtr1 = startPtr;
+      m_endPtr1 = endPtr;
+      m_control1 = control;
+    }
+    DEBUG5("SYNC corr BS Voice found slot/pos/start/end: ", m_slot ? 2U : 1U, m_dataPtr, startPtr, endPtr);
   }
 }
 


### PR DESCRIPTION
…eld radio) emulation.

The firmware now both transmits and receives as a handheld radio, allowing it to communicate with DMR repeaters as a standard subscriber unit.

The following changes have been made:
1.  **Transmitter (TX):** The `writeData1()` and `writeData2()` functions in `DMRTX.cpp` have been modified to replace Base Station (BS) sync patterns with Mobile Station (MS) sync patterns in all outgoing frames.
2.  **Receiver (RX):** The `correlateSync()` function in `DMRSlotRX.cpp` has been updated to detect both MS and BS sync patterns, enabling the board to receive transmissions from both handhelds and repeaters.