### PR TITLE
feat: Implement robust TS2-only operation and DMR handshake

### DIFF
--- a/DMRTX.h
+++ b/DMRTX.h
@@ -31,6 +31,8 @@
 
 enum DMRTXSTATE {
   DMRTXSTATE_IDLE,
+  DMRTXSTATE_REQUEST_CHANNEL,
+  DMRTXSTATE_WAIT_BS_CONFIRM,
   DMRTXSTATE_SLOT1,
   DMRTXSTATE_CACH1,
   DMRTXSTATE_SLOT2,
@@ -56,6 +58,8 @@ public:
   uint8_t getSpace2() const;
 
   void setColorCode(uint8_t colorCode);
+  void confirmBSSync();
+  bool isWaitingForBSSync() const;
 
 private:
   CSerialRB                        m_fifo[2U];
@@ -71,8 +75,11 @@ private:
   uint32_t                         m_frameCount;
   bool                             m_abort[2U];
   uint8_t                          m_control_old;
+  bool                             m_bs_sync_confirmed;
+  uint8_t                          m_wait_timeout;
+  uint8_t                          m_request_retries;
 
-  void createData(uint8_t slotIndex);
+  void createData(uint8_t slotIndex, bool forceIdle = false);
   void createCACH(uint8_t txSlotIndex, uint8_t rxSlotIndex);
   void writeByte(uint8_t c, uint8_t control);
 };


### PR DESCRIPTION
This commit provides a final, robust solution for Mobile Station (MS) emulation, addressing all previous issues and implementing a correct and reliable handshake mechanism.

The following changes were made:

1.  **Clean TS2-Only Operation:**
    - **`DMRTX.cpp`**: Disabled `writeData1()` to prevent any transmission on Time Slot 1.
    - **`DMRSlotRX.cpp`**: Refactored to cleanly ignore all incoming traffic on Time Slot 1 by adding a guard clause to `correlateSync()` and removing the call to `procSlot1()`.

2.  **Correct and Robust DMR Handshake:**
    - **`DMRTX.h`**: Added new states (`DMRTXSTATE_REQUEST_CHANNEL`, `DMRTXSTATE_WAIT_BS_CONFIRM`) and variables to manage the handshake, including a retry counter.
    - **`DMRTX.cpp`**:
      - Implemented a new state machine in `process()` that correctly handles the handshake flow:
        1.  Sends a channel request (idle frame) on Time Slot 2.
        2.  Waits for a confirmation from the Base Station. 3.  Includes a timeout and a retry mechanism to re-request the channel up to 3 times before aborting. - `createData()` was updated with a `forceIdle` parameter to enable sending the channel request without consuming user data. - `writeData2()` now initiates this robust handshake process.
    - **`DMRSlotRX.cpp`**: - `correlateSync()` now notifies the transmitter to complete the handshake only when it detects a BS sync *and* the transmitter is in the waiting state.