### PR TITLE
Refactor firmware for Time Slot 2-only operation and implement a robu…

### DIFF
--- a/DMRSlotRX.cpp
+++ b/DMRSlotRX.cpp
@@ -46,22 +46,14 @@ m_slot(false),
 m_patternBuffer(0x00U),
 m_buffer(),
 m_dataPtr(0U),
-m_syncPtr1(0U),
-m_startPtr1(0U),
-m_endPtr1(NOENDPTR),
-m_control1(CONTROL_NONE),
-m_syncCount1(0U),
-m_state1(DMRRXS_NONE),
-m_n1(0U),
-m_type1(0U),
-m_syncPtr2(0U),
-m_startPtr2(0U),
-m_endPtr2(NOENDPTR),
-m_control2(CONTROL_NONE),
-m_syncCount2(0U),
-m_state2(DMRRXS_NONE),
-m_n2(0U),
-m_type2(0U),
+m_syncPtr(0U),
+m_startPtr(0U),
+m_endPtr(NOENDPTR),
+m_control(CONTROL_NONE),
+m_syncCount(0U),
+m_state(DMRRXS_NONE),
+m_n(0U),
+m_type(0U),
 m_delayPtr(0U),
 m_colorCode(0U),
 m_delay(0U)
@@ -80,41 +72,28 @@ void CDMRSlotRX::reset()
   m_delayPtr  = 0U;
   m_patternBuffer = 0U;
 
-  reset1();
-  reset2();
-}
-
-void CDMRSlotRX::reset1()
-{
-  m_syncPtr1   = 0U;
-  m_control1   = CONTROL_NONE;
-  m_syncCount1 = 0U;
-  m_state1     = DMRRXS_NONE;
-  m_startPtr1  = 0U;
-  m_endPtr1    = NOENDPTR;
-  m_type1      = 0U;
-  m_n1         = 0U;
-}
-
-void CDMRSlotRX::reset2()
-{
-  m_syncPtr2   = 0U;
-  m_control2   = CONTROL_NONE;
-  m_syncCount2 = 0U;
-  m_state2     = DMRRXS_NONE;
-  m_startPtr2  = 0U;
-  m_endPtr2    = NOENDPTR;
-  m_type2      = 0U;
-  m_n2         = 0U;
+  m_syncPtr   = 0U;
+  m_control   = CONTROL_NONE;
+  m_syncCount = 0U;
+  m_state     = DMRRXS_NONE;
+  m_startPtr  = 0U;
+  m_endPtr    = NOENDPTR;
+  m_type      = 0U;
+  m_n         = 0U;
 }
 
 bool CDMRSlotRX::databit(bool bit)
 {
+  // Only process TS2
+  if (!m_slot) {
+      return (m_state != DMRRXS_NONE);
+  }
+
   uint16_t min, max;
 
   m_delayPtr++;
   if (m_delayPtr < m_delay)
-    return (m_state1 != DMRRXS_NONE) || (m_state2 != DMRRXS_NONE);
+    return (m_state != DMRRXS_NONE);
 
   WRITE_BIT1(m_buffer, m_dataPtr, bit);
 
@@ -122,16 +101,11 @@ bool CDMRSlotRX::databit(bool bit)
   if (bit)
     m_patternBuffer |= 0x01U;
     
-  if (m_state1 == DMRRXS_NONE || m_state2 == DMRRXS_NONE) {
+  if (m_state == DMRRXS_NONE) {
     correlateSync();
   } else {
-    if(m_slot) {
-      min = m_syncPtr2 + DMR_BUFFER_LENGTH_BITS - 2;
-      max = m_syncPtr2 + 2;
-    } else {
-      min = m_syncPtr1 + DMR_BUFFER_LENGTH_BITS - 2;
-      max = m_syncPtr1 + 2;
-    }
+    min = m_syncPtr + DMR_BUFFER_LENGTH_BITS - 2;
+    max = m_syncPtr + 2;
 
     if (min >= DMR_BUFFER_LENGTH_BITS)
       min -= DMR_BUFFER_LENGTH_BITS;
@@ -147,280 +121,149 @@ bool CDMRSlotRX::databit(bool bit)
     }
   }
 
-  if(m_slot)
-    procSlot2();
-  else
-    procSlot1();
+  procSlot2();
 
   m_dataPtr++;
 
   if (m_dataPtr >= DMR_BUFFER_LENGTH_BITS)
     m_dataPtr = 0U;
 
-  return (m_state1 != DMRRXS_NONE) || (m_state2 != DMRRXS_NONE);;
-}
-
-void CDMRSlotRX::procSlot1()
-{
-  if (m_dataPtr == m_endPtr1) {
-    frame1[0U] = m_control1;
-
-    bitsToBytes(m_startPtr1, DMR_FRAME_LENGTH_BYTES, frame1 + 1U);
-
-    if (m_control1 == CONTROL_DATA) {
-      // Data sync
-      uint8_t colorCode;
-      uint8_t dataType;
-      CDMRSlotType slotType;
-      slotType.decode(frame1 + 1U, colorCode, dataType);
-
-      if (colorCode == m_colorCode) {
-        m_syncCount1 = 0U;
-        m_n1         = 0U;
-
-        frame1[0U] |= dataType;
-
-        switch (dataType) {
-          case DT_DATA_HEADER:
-            DEBUG2("DMRSlot1RX: data header found pos", m_syncPtr1);
-            writeRSSIData1();
-            m_state1 = DMRRXS_DATA;
-            m_type1  = 0x00U;
-            break;
-          case DT_RATE_12_DATA:
-          case DT_RATE_34_DATA:
-          case DT_RATE_1_DATA:
-            if (m_state1 == DMRRXS_DATA) {
-              DEBUG2("DMRSlot1RX: data payload found pos", m_syncPtr1);
-              writeRSSIData1();
-              m_type1 = dataType;
-            }
-            break;
-          case DT_VOICE_LC_HEADER:
-            DEBUG2("DMRSlot1RX: voice header found pos", m_syncPtr1);
-            writeRSSIData1();
-            m_state1 = DMRRXS_VOICE;
-            break;
-          case DT_VOICE_PI_HEADER:
-            if (m_state1 == DMRRXS_VOICE) {
-              DEBUG2("DMRSlot1RX: voice pi header found pos", m_syncPtr1);
-              writeRSSIData1();
-            }
-            m_state1 = DMRRXS_VOICE;
-            break;
-          case DT_TERMINATOR_WITH_LC:
-            if (m_state1 == DMRRXS_VOICE) {
-              DEBUG2("DMRSlot1RX: voice terminator found pos", m_syncPtr1);
-              writeRSSIData1();
-              m_state1  = DMRRXS_NONE;
-              m_endPtr1 = NOENDPTR;
-            }
-            break;
-          default:    // DT_CSBK
-            DEBUG2("DMRSlot1RX: csbk found pos", m_syncPtr1);
-            writeRSSIData1();
-            m_state1  = DMRRXS_NONE;
-            m_endPtr1 = NOENDPTR;
-            break;
-        }
-      }
-    } else if (m_control1 == CONTROL_VOICE) {
-      // Voice sync
-      DEBUG2("DMRSlot1RX: voice sync found pos", m_syncPtr1);
-      writeRSSIData1();
-      m_state1     = DMRRXS_VOICE;
-      m_syncCount1 = 0U;
-      m_n1         = 0U;
-    } else {
-      if (m_state1 != DMRRXS_NONE) {
-        m_syncCount1++;
-        if (m_syncCount1 >= MAX_SYNC_LOST_FRAMES) {
-          serial.writeDMRLost(0U);
-          reset1();
-        }
-      }
-
-      if (m_state1 == DMRRXS_VOICE) {
-        if (m_n1 >= 5U) {
-          frame1[0U] = CONTROL_VOICE;
-          m_n1 = 0U;
-        } else {
-          frame1[0U] = ++m_n1;
-        }
-
-        serial.writeDMRData(0U, frame1, DMR_FRAME_LENGTH_BYTES + 1U);
-      } else if (m_state1 == DMRRXS_DATA) {
-        if (m_type1 != 0x00U) {
-          frame1[0U] = CONTROL_DATA | m_type1;
-          writeRSSIData1();
-        }
-      }
-    }
-
-    // End of this slot, reset some items for the next slot.
-    m_control1 = CONTROL_NONE;
-  }
+  return (m_state != DMRRXS_NONE);;
 }
 
 void CDMRSlotRX::procSlot2()
 {
-  if (m_dataPtr == m_endPtr2) {
-    frame2[0U] = m_control2;
+  if (m_dataPtr == m_endPtr) {
+    frame[0U] = m_control;
 
-    bitsToBytes(m_startPtr2, DMR_FRAME_LENGTH_BYTES, frame2 + 1U);
+    bitsToBytes(m_startPtr, DMR_FRAME_LENGTH_BYTES, frame + 1U);
 
-    if (m_control2 == CONTROL_DATA) {
+    if (m_control == CONTROL_DATA) {
       // Data sync
       uint8_t colorCode;
       uint8_t dataType;
       CDMRSlotType slotType;
-      slotType.decode(frame2 + 1U, colorCode, dataType);
+      slotType.decode(frame + 1U, colorCode, dataType);
 
       if (colorCode == m_colorCode) {
-        m_syncCount2 = 0U;
-        m_n2         = 0U;
+        m_syncCount = 0U;
+        m_n         = 0U;
 
-        frame2[0U] |= dataType;
+        frame[0U] |= dataType;
 
         switch (dataType) {
           case DT_DATA_HEADER:
-            DEBUG2("DMRSlot2RX: data header found pos", m_syncPtr2);
-            writeRSSIData2();
-            m_state2 = DMRRXS_DATA;
-            m_type2  = 0x00U;
+            DEBUG2("DMRSlot2RX: data header found pos", m_syncPtr);
+            writeRSSIData();
+            m_state = DMRRXS_DATA;
+            m_type  = 0x00U;
             break;
           case DT_RATE_12_DATA:
           case DT_RATE_34_DATA:
           case DT_RATE_1_DATA:
-            if (m_state2 == DMRRXS_DATA) {
-              DEBUG2("DMRSlot2RX: data payload found pos", m_syncPtr2);
-              writeRSSIData2();
-              m_type2 = dataType;
+            if (m_state == DMRRXS_DATA) {
+              DEBUG2("DMRSlot2RX: data payload found pos", m_syncPtr);
+              writeRSSIData();
+              m_type = dataType;
             }
             break;
           case DT_VOICE_LC_HEADER:
-            DEBUG2("DMRSlot2RX: voice header found pos", m_syncPtr2);
-            writeRSSIData2();
-            m_state2 = DMRRXS_VOICE;
+            DEBUG2("DMRSlot2RX: voice header found pos", m_syncPtr);
+            writeRSSIData();
+            m_state = DMRRXS_VOICE;
             break;
           case DT_VOICE_PI_HEADER:
-            if (m_state2 == DMRRXS_VOICE) {
-              DEBUG2("DMRSlot2RX: voice pi header found pos", m_syncPtr2);
-              writeRSSIData2();
+            if (m_state == DMRRXS_VOICE) {
+              DEBUG2("DMRSlot2RX: voice pi header found pos", m_syncPtr);
+              writeRSSIData();
             }
-            m_state2 = DMRRXS_VOICE;
+            m_state = DMRRXS_VOICE;
             break;
           case DT_TERMINATOR_WITH_LC:
-            if (m_state2 == DMRRXS_VOICE) {
-              DEBUG2("DMRSlot2RX: voice terminator found pos", m_syncPtr2);
-              writeRSSIData2();
-              m_state2  = DMRRXS_NONE;
-              m_endPtr2 = NOENDPTR;
+            if (m_state == DMRRXS_VOICE) {
+              DEBUG2("DMRSlot2RX: voice terminator found pos", m_syncPtr);
+              writeRSSIData();
+              m_state  = DMRRXS_NONE;
+              m_endPtr = NOENDPTR;
             }
             break;
           default:    // DT_CSBK
-            DEBUG2("DMRSlot2RX: csbk found pos", m_syncPtr2);
-            writeRSSIData2();
-            m_state2  = DMRRXS_NONE;
-            m_endPtr2 = NOENDPTR;
+            DEBUG2("DMRSlot2RX: csbk found pos", m_syncPtr);
+            writeRSSIData();
+            m_state  = DMRRXS_NONE;
+            m_endPtr = NOENDPTR;
             break;
         }
       }
-    } else if (m_control2 == CONTROL_VOICE) {
+    } else if (m_control == CONTROL_VOICE) {
       // Voice sync
-      DEBUG2("DMRSlot2RX: voice sync found pos", m_syncPtr2);
-      writeRSSIData2();
-      m_state2     = DMRRXS_VOICE;
-      m_syncCount2 = 0U;
-      m_n2         = 0U;
+      DEBUG2("DMRSlot2RX: voice sync found pos", m_syncPtr);
+      writeRSSIData();
+      m_state     = DMRRXS_VOICE;
+      m_syncCount = 0U;
+      m_n         = 0U;
     } else {
-      if (m_state2 != DMRRXS_NONE) {
-        m_syncCount2++;
-        if (m_syncCount2 >= MAX_SYNC_LOST_FRAMES) {
+      if (m_state != DMRRXS_NONE) {
+        m_syncCount++;
+        if (m_syncCount >= MAX_SYNC_LOST_FRAMES) {
           serial.writeDMRLost(1U);
-          reset2();
+          reset();
         }
       }
 
-      if (m_state2 == DMRRXS_VOICE) {
-        if (m_n2 >= 5U) {
-          frame2[0U] = CONTROL_VOICE;
-          m_n2 = 0U;
+      if (m_state == DMRRXS_VOICE) {
+        if (m_n >= 5U) {
+          frame[0U] = CONTROL_VOICE;
+          m_n = 0U;
         } else {
-          frame2[0U] = ++m_n2;
+          frame[0U] = ++m_n;
         }
 
-        serial.writeDMRData(1U, frame2, DMR_FRAME_LENGTH_BYTES + 1U);
-      } else if (m_state2 == DMRRXS_DATA) {
-        if (m_type2 != 0x00U) {
-          frame2[0U] = CONTROL_DATA | m_type2;
-          writeRSSIData2();
+        serial.writeDMRData(1U, frame, DMR_FRAME_LENGTH_BYTES + 1U);
+      } else if (m_state == DMRRXS_DATA) {
+        if (m_type != 0x00U) {
+          frame[0U] = CONTROL_DATA | m_type;
+          writeRSSIData();
         }
       }
     }
 
     // End of this slot, reset some items for the next slot.
-    m_control2 = CONTROL_NONE;
+    m_control = CONTROL_NONE;
   }
 }
 
 void CDMRSlotRX::correlateSync()
 {
+  if (!m_slot) // Only process TS2
+    return;
+
   uint16_t syncPtr;
   uint16_t startPtr;
   uint16_t endPtr;
-  uint8_t  control;
+  uint8_t  control = CONTROL_NONE;
 
   if (countBits64((m_patternBuffer & DMR_SYNC_BITS_MASK) ^ DMR_MS_DATA_SYNC_BITS) <= MAX_SYNC_BYTES_ERRS) {
     control = CONTROL_DATA;
-    syncPtr = m_dataPtr;
-
-    startPtr = m_dataPtr + DMR_BUFFER_LENGTH_BITS - DMR_SLOT_TYPE_LENGTH_BITS / 2U - DMR_INFO_LENGTH_BITS / 2U - DMR_SYNC_LENGTH_BITS + 1;
-    if (startPtr >= DMR_BUFFER_LENGTH_BITS)
-      startPtr -= DMR_BUFFER_LENGTH_BITS;
-
-    endPtr = m_dataPtr + DMR_SLOT_TYPE_LENGTH_BITS / 2U + DMR_INFO_LENGTH_BITS / 2U;
-    if (endPtr >= DMR_BUFFER_LENGTH_BITS)
-      endPtr -= DMR_BUFFER_LENGTH_BITS;
-
-    if(m_slot) {
-      m_syncPtr2 = syncPtr;
-      m_startPtr2 = startPtr;
-      m_endPtr2 = endPtr;
-      m_control2 = control;
-    } else {
-      m_syncPtr1 = syncPtr;
-      m_startPtr1 = startPtr;
-      m_endPtr1 = endPtr;
-      m_control1 = control;
-    }
-    DEBUG5("SYNC corr MS Data found slot/pos/start/end:", m_slot ? 2U : 1U, m_dataPtr, startPtr, endPtr);
   } else if (countBits64((m_patternBuffer & DMR_SYNC_BITS_MASK) ^ DMR_MS_VOICE_SYNC_BITS) <= MAX_SYNC_BYTES_ERRS) {
-    control  = CONTROL_VOICE;
-    syncPtr  = m_dataPtr;
-
-    startPtr = m_dataPtr + DMR_BUFFER_LENGTH_BITS - DMR_SLOT_TYPE_LENGTH_BITS / 2U - DMR_INFO_LENGTH_BITS / 2U - DMR_SYNC_LENGTH_BITS + 1;
-    if (startPtr >= DMR_BUFFER_LENGTH_BITS)
-      startPtr -= DMR_BUFFER_LENGTH_BITS;
-
-    endPtr   = m_dataPtr + DMR_SLOT_TYPE_LENGTH_BITS / 2U + DMR_INFO_LENGTH_BITS / 2U;
-    if (endPtr >= DMR_BUFFER_LENGTH_BITS)
-      endPtr -= DMR_BUFFER_LENGTH_BITS;
-
-    if(m_slot) {
-      m_syncPtr2 = syncPtr;
-      m_startPtr2 = startPtr;
-      m_endPtr2 = endPtr;
-      m_control2 = control;
-    } else {
-      m_syncPtr1 = syncPtr;
-      m_startPtr1 = startPtr;
-      m_endPtr1 = endPtr;
-      m_control1 = control;
-    }
-    DEBUG5("SYNC corr MS Voice found slot/pos/start/end: ", m_slot ? 2U : 1U, m_dataPtr, startPtr, endPtr);
+    control = CONTROL_VOICE;
   } else if (countBits64((m_patternBuffer & DMR_SYNC_BITS_MASK) ^ DMR_BS_DATA_SYNC_BITS) <= MAX_SYNC_BYTES_ERRS) {
-    control = CONTROL_DATA;
+    if (dmrTX.isWaitingForBSSync()) {
+      dmrTX.confirmBSSync();
+    }
+    reset(); // Always ignore BS frames
+    DEBUG2("DMRSlotRX: ignored BS data sync on slot", 2);
+    return;
+  } else if (countBits64((m_patternBuffer & DMR_SYNC_BITS_MASK) ^ DMR_BS_VOICE_SYNC_BITS) <= MAX_SYNC_BYTES_ERRS) {
+    if (dmrTX.isWaitingForBSSync()) {
+      dmrTX.confirmBSSync();
+    }
+    reset(); // Always ignore BS frames
+    DEBUG2("DMRSlotRX: ignored BS voice sync on slot", 2);
+    return;
+  }
+
+  if (control != CONTROL_NONE) {
     syncPtr = m_dataPtr;
 
     startPtr = m_dataPtr + DMR_BUFFER_LENGTH_BITS - DMR_SLOT_TYPE_LENGTH_BITS / 2U - DMR_INFO_LENGTH_BITS / 2U - DMR_SYNC_LENGTH_BITS + 1;
@@ -431,42 +274,16 @@ void CDMRSlotRX::correlateSync()
     if (endPtr >= DMR_BUFFER_LENGTH_BITS)
       endPtr -= DMR_BUFFER_LENGTH_BITS;
 
-    if(m_slot) {
-      m_syncPtr2 = syncPtr;
-      m_startPtr2 = startPtr;
-      m_endPtr2 = endPtr;
-      m_control2 = control;
+    m_syncPtr = syncPtr;
+    m_startPtr = startPtr;
+    m_endPtr = endPtr;
+    m_control = control;
+
+    if (control == CONTROL_DATA) {
+        DEBUG5("SYNC corr MS Data found slot/pos/start/end:", 2U, m_dataPtr, startPtr, endPtr);
     } else {
-      m_syncPtr1 = syncPtr;
-      m_startPtr1 = startPtr;
-      m_endPtr1 = endPtr;
-      m_control1 = control;
+        DEBUG5("SYNC corr MS Voice found slot/pos/start/end: ", 2U, m_dataPtr, startPtr, endPtr);
     }
-    DEBUG5("SYNC corr BS Data found slot/pos/start/end:", m_slot ? 2U : 1U, m_dataPtr, startPtr, endPtr);
-  } else if (countBits64((m_patternBuffer & DMR_SYNC_BITS_MASK) ^ DMR_BS_VOICE_SYNC_BITS) <= MAX_SYNC_BYTES_ERRS) {
-    control  = CONTROL_VOICE;
-    syncPtr  = m_dataPtr;
-
-    startPtr = m_dataPtr + DMR_BUFFER_LENGTH_BITS - DMR_SLOT_TYPE_LENGTH_BITS / 2U - DMR_INFO_LENGTH_BITS / 2U - DMR_SYNC_LENGTH_BITS + 1;
-    if (startPtr >= DMR_BUFFER_LENGTH_BITS)
-      startPtr -= DMR_BUFFER_LENGTH_BITS;
-
-    endPtr   = m_dataPtr + DMR_SLOT_TYPE_LENGTH_BITS / 2U + DMR_INFO_LENGTH_BITS / 2U;
-    if (endPtr >= DMR_BUFFER_LENGTH_BITS)
-      endPtr -= DMR_BUFFER_LENGTH_BITS;
-
-    if(m_slot) {
-      m_syncPtr2 = syncPtr;
-      m_startPtr2 = startPtr;
-      m_endPtr2 = endPtr;
-      m_control2 = control;
-    } else {
-      m_syncPtr1 = syncPtr;
-      m_startPtr1 = startPtr;
-      m_endPtr1 = endPtr;
-      m_control1 = control;
-    }
-    DEBUG5("SYNC corr BS Voice found slot/pos/start/end: ", m_slot ? 2U : 1U, m_dataPtr, startPtr, endPtr);
   }
 }
 
@@ -519,31 +336,17 @@ void CDMRSlotRX::setDelay(uint8_t delay)
   m_delay = delay / 5;
 }
 
-void CDMRSlotRX::writeRSSIData1()
+void CDMRSlotRX::writeRSSIData()
 {
 #if defined(SEND_RSSI_DATA)
   uint16_t rssi = io.readRSSI();
 
-  frame1[34U] = (rssi >> 8) & 0xFFU;
-  frame1[35U] = (rssi >> 0) & 0xFFU;
+  frame[34U] = (rssi >> 8) & 0xFFU;
+  frame[35U] = (rssi >> 0) & 0xFFU;
 
-  serial.writeDMRData(0U, frame1, DMR_FRAME_LENGTH_BYTES + 3U);
+  serial.writeDMRData(1U, frame, DMR_FRAME_LENGTH_BYTES + 3U);
 #else
-  serial.writeDMRData(0U, frame1, DMR_FRAME_LENGTH_BYTES + 1U);
-#endif
-}
-
-void CDMRSlotRX::writeRSSIData2()
-{
-#if defined(SEND_RSSI_DATA)
-  uint16_t rssi = io.readRSSI();
-
-  frame2[34U] = (rssi >> 8) & 0xFFU;
-  frame2[35U] = (rssi >> 0) & 0xFFU;
-
-  serial.writeDMRData(1U, frame2, DMR_FRAME_LENGTH_BYTES + 3U);
-#else
-  serial.writeDMRData(1U, frame2, DMR_FRAME_LENGTH_BYTES + 1U);
+  serial.writeDMRData(1U, frame, DMR_FRAME_LENGTH_BYTES + 1U);
 #endif
 }
 

--- a/DMRSlotRX.h
+++ b/DMRSlotRX.h
@@ -53,38 +53,24 @@ private:
   uint8_t     m_buffer[DMR_BUFFER_LENGTH_BITS / 8U];  // 72 bytes
   uint16_t    m_dataPtr;
 
-  uint8_t     frame1[DMR_FRAME_LENGTH_BYTES + 3U];
-  uint16_t    m_syncPtr1;
-  uint16_t    m_startPtr1;
-  uint16_t    m_endPtr1;
-  uint8_t     m_control1;
-  uint8_t     m_syncCount1;
-  DMRRX_STATE m_state1;
-  uint8_t     m_n1;
-  uint8_t     m_type1;
-
-  uint8_t     frame2[DMR_FRAME_LENGTH_BYTES + 3U];
-  uint16_t    m_syncPtr2;
-  uint16_t    m_startPtr2;
-  uint16_t    m_endPtr2;
-  uint8_t     m_control2;
-  uint8_t     m_syncCount2;
-  DMRRX_STATE m_state2;
-  uint8_t     m_n2;
-  uint8_t     m_type2;
+  uint8_t     frame[DMR_FRAME_LENGTH_BYTES + 3U];
+  uint16_t    m_syncPtr;
+  uint16_t    m_startPtr;
+  uint16_t    m_endPtr;
+  uint8_t     m_control;
+  uint8_t     m_syncCount;
+  DMRRX_STATE m_state;
+  uint8_t     m_n;
+  uint8_t     m_type;
 
   uint16_t    m_delayPtr;
   uint8_t     m_colorCode;
   uint16_t    m_delay;
 
-  void procSlot1();
   void procSlot2();
   void correlateSync();
   void bitsToBytes(uint16_t start, uint8_t count, uint8_t* buffer);
-  void writeRSSIData1();
-  void writeRSSIData2();
-  void reset1();
-  void reset2();
+  void writeRSSIData();
 };
 
 #endif

--- a/DMRTX.h
+++ b/DMRTX.h
@@ -31,6 +31,8 @@
 
 enum DMRTXSTATE {
   DMRTXSTATE_IDLE,
+  DMRTXSTATE_REQUEST_CHANNEL,
+  DMRTXSTATE_WAIT_BS_CONFIRM,
   DMRTXSTATE_SLOT1,
   DMRTXSTATE_CACH1,
   DMRTXSTATE_SLOT2,
@@ -48,7 +50,7 @@ public:
   uint8_t writeShortLC(const uint8_t* data, uint8_t length);
   uint8_t writeAbort(const uint8_t* data, uint8_t length);
 
-  void setStart(bool start);
+  void reset();
 
   void process();
 
@@ -56,6 +58,8 @@ public:
   uint8_t getSpace2() const;
 
   void setColorCode(uint8_t colorCode);
+  void confirmBSSync();
+  bool isWaitingForBSSync() const;
 
 private:
   CSerialRB                        m_fifo[2U];
@@ -71,8 +75,11 @@ private:
   uint32_t                         m_frameCount;
   bool                             m_abort[2U];
   uint8_t                          m_control_old;
+  bool                             m_bs_sync_confirmed;
+  uint8_t                          m_wait_timeout;
+  uint8_t                          m_request_retries;
 
-  void createData(uint8_t slotIndex);
+  void createData(uint8_t slotIndex, bool forceIdle = false);
   void createCACH(uint8_t txSlotIndex, uint8_t rxSlotIndex);
   void writeByte(uint8_t c, uint8_t control);
 };

--- a/GitVersion.h
+++ b/GitVersion.h
@@ -1,0 +1,1 @@
+#define GITVERSION "a6bd8bd"

--- a/SerialPort.cpp
+++ b/SerialPort.cpp
@@ -771,13 +771,14 @@ void CSerialPort::process()
             if (m_dmrEnable) {
               err = 4U;
               if (m_len == 4U) {
+                // The concept of starting the transmitter without data is now obsolete.
+                // The transmitter is started by the arrival of data.
                 if (m_buffer[3U] == 0x01U && m_modemState == STATE_DMR) {
-                  if (!m_tx)
-                    dmrTX.setStart(true);
                   err = 0U;
                 } else if (m_buffer[3U] == 0x00U && m_modemState == STATE_DMR) {
+                  // A value of 0 indicates a request to stop transmitting.
                   if (m_tx)
-                    dmrTX.setStart(false);
+                    dmrTX.reset();
                   err = 0U;
                 }
               }


### PR DESCRIPTION
…st DMR handshake mechanism.

possible duplicate
This commit introduces significant changes to the firmware to align with the user's goal of operating the MMDVM hotspot as a Mobile Station (MS) on a single time slot (TS2).

Key changes include:

1.  **TS2-Only Refactoring:**
    - The `DMRSlotRX` class has been heavily refactored to remove all logic and variables related to Time Slot 1, simplifying the receiver code to focus exclusively on TS2.
    - The `DMRTX` class now ignores incoming data for TS1, preventing any transmissions on that slot.

2.  **Robust DMR Handshake:**
    - A new state machine has been implemented in `DMRTX.cpp` to manage the DMR handshake process.
    - When data is ready for transmission, the hotspot first sends an idle frame to request the channel (`DMRTXSTATE_REQUEST_CHANNEL`).
    - It then enters a waiting state (`DMRTXSTATE_WAIT_BS_CONFIRM`), continuously transmitting idle frames to keep the channel open while waiting for a confirmation from the Base Station.
    - A timeout and retry mechanism (3 retries) has been added to prevent the transmitter from getting stuck if no confirmation is received.

3.  **MS Sync Correction:**
    - The transmitter now unconditionally uses the correct Mobile Station (MS) sync patterns for all outgoing voice and data frames on TS2, ensuring proper communication with a Base Station repeater.

4.  **Code Cleanup and Fixes:**
    - Replaced the obsolete `setStart()` function with a `reset()` function in `DMRTX`, and updated the call sites in `SerialPort.cpp` accordingly.
    - Implemented the `writeAbort()` function in `DMRTX` to correctly handle abort commands.