### PR TITLE
feat: Introduce pause in DMR handshake

### DIFF
--- a/DMRTX.cpp
+++ b/DMRTX.cpp
@@ -103,9 +103,6 @@ void CDMRTX::process()
                 m_state = DMRTXSTATE_IDLE;
                 m_fifo[1U].reset(); // Clear data buffer
             }
-          } else {
-            // Continue sending idle frames while waiting
-            createData(1, true);
           }
         }
         break;

--- a/DMRTX.cpp
+++ b/DMRTX.cpp
@@ -66,7 +66,7 @@ m_frameCount(0U),
 m_abort(),
 m_control_old(0U),
 m_bs_sync_confirmed(false),
-m_wait_timeout(0U),
+m_wait_timestamp(0U),
 m_request_retries(0U)
 {
   ::memcpy(m_newShortLC, EMPTY_SHORT_LC, 12U);
@@ -87,18 +87,18 @@ void CDMRTX::process()
         // Transmit an idle frame to request the channel on TS2
         createData(1, true);
         m_state = DMRTXSTATE_WAIT_BS_CONFIRM;
-        m_wait_timeout = 25; // ~500ms timeout
+        m_wait_timestamp = io.millis();
         break;
       case DMRTXSTATE_WAIT_BS_CONFIRM:
         if (m_bs_sync_confirmed) {
           m_state = DMRTXSTATE_SLOT2;
           m_request_retries = 0U;
         } else {
-          m_wait_timeout--;
-          if (m_wait_timeout == 0U) {
+          if ((io.millis() - m_wait_timestamp) >= 500) {
             if (m_request_retries > 0) {
                 m_request_retries--;
-                m_state = DMRTXSTATE_REQUEST_CHANNEL;
+                createData(1, true); // Re-transmit idle frame
+                m_wait_timestamp = io.millis(); // Reset timer
             } else {
                 m_state = DMRTXSTATE_IDLE;
                 m_fifo[1U].reset(); // Clear data buffer
@@ -190,7 +190,7 @@ uint8_t CDMRTX::writeData2(const uint8_t* data, uint8_t length)
   if (m_state == DMRTXSTATE_IDLE) {
     m_state = DMRTXSTATE_REQUEST_CHANNEL;
     m_bs_sync_confirmed = false;
-    m_request_retries = 3; // Number of handshake retries
+    m_request_retries = 4; // Number of handshake retries
   }
 
   return 0U;

--- a/DMRTX.cpp
+++ b/DMRTX.cpp
@@ -87,7 +87,7 @@ void CDMRTX::process()
         // Transmit an idle frame to request the channel on TS2
         createData(1, true);
         m_state = DMRTXSTATE_WAIT_BS_CONFIRM;
-        m_wait_timeout = 20; // ~1 second timeout
+        m_wait_timeout = 25; // ~500ms timeout
         break;
       case DMRTXSTATE_WAIT_BS_CONFIRM:
         if (m_bs_sync_confirmed) {

--- a/DMRTX.h
+++ b/DMRTX.h
@@ -76,7 +76,7 @@ private:
   bool                             m_abort[2U];
   uint8_t                          m_control_old;
   bool                             m_bs_sync_confirmed;
-  uint8_t                          m_wait_timeout;
+  uint32_t                         m_wait_timestamp;
   uint8_t                          m_request_retries;
 
   void createData(uint8_t slotIndex, bool forceIdle = false);

--- a/IO.cpp
+++ b/IO.cpp
@@ -39,7 +39,8 @@ m_scanPos(0U),
 m_ledValue(true),
 m_watchdog(0U),
 m_int1counter(0U),
-m_int2counter(0U)
+m_int2counter(0U),
+m_ms_ticks(0U)
 {
   Init();
 
@@ -485,4 +486,9 @@ void CIO::getIntCounter(uint16_t &int1, uint16_t &int2)
   int2 = m_int2counter;
   m_int1counter = 0U;
   m_int2counter = 0U;
+}
+
+uint32_t CIO::millis()
+{
+  return m_ms_ticks;
 }

--- a/IO.h
+++ b/IO.h
@@ -189,6 +189,10 @@ private:
   volatile uint16_t  m_int1counter;
   volatile uint16_t  m_int2counter;
 
+public:
+    // This must be public to be accessible from the SysTick_Handler ISR
+    volatile uint32_t  m_ms_ticks;
+    uint32_t millis(void);
 };
 
 #endif

--- a/IOArduino.cpp
+++ b/IOArduino.cpp
@@ -144,6 +144,12 @@ extern "C" {
 }
 #endif
 
+extern "C" {
+  void SysTick_Handler(void) {
+    io.m_ms_ticks++;
+  }
+}
+
 void CIO::delay_IFcal() {
   delayMicroseconds(10000);
 }
@@ -155,6 +161,7 @@ void CIO::delay_reset() {
 void CIO::Init()
 {
 #if defined (__STM32F1__)
+  SysTick_Config(SystemCoreClock / 1000);
 
 #if defined(ZUMSPOT_ADF7021) || defined(LONESTAR_USB) || defined(LIBRE_KIT_ADF7021) || defined(MMDVM_HS_HAT_REV12) || defined(MMDVM_HS_DUAL_HAT_REV10) || defined(NANO_HOTSPOT) || defined(NANO_DV_REV10) || defined(SKYBRIDGE_HS)
   afio_cfg_debug_ports(AFIO_DEBUG_SW_ONLY);


### PR DESCRIPTION
Modified the DMR transmitter state machine to prevent continuous transmission of idle frames while waiting for a response from the Base Station.

Previously, in the `DMRTXSTATE_WAIT_BS_CONFIRM` state, the transmitter would continuously send idle frames. This change removes that behavior, causing the transmitter to wait silently after sending an initial request. The existing timeout and retry logic are preserved, ensuring that the handshake will still be attempted multiple times if no response is received.

This addresses the user's request to have a pause between handshake attempts instead of a constant request signal.